### PR TITLE
If browser is ie , invoke $.hide function when trigger close event

### DIFF
--- a/photobox/photobox.js
+++ b/photobox/photobox.js
@@ -335,7 +335,7 @@
 			jQuery.browser.msie && hide();
 
 			function hide(){
-				$(overlay).removeClass('show hide on');
+				$(overlay).hide().removeClass('show hide on');
 				$(image).removeAttr('class').removeAttr('src').removeAttr('style').off().data('zoom',1);
 			}
 			


### PR DESCRIPTION
Hi, I use photobox in IE 10 , when I close the gallery, photobox overlay still exist but it opacity is 0, and I click anything that always trigger the close event, so I add $.hide function in gallery close.
