### PR TITLE
idempotent doc ready handler (turbolinks compat)

### DIFF
--- a/photobox/photobox.js
+++ b/photobox/photobox.js
@@ -61,9 +61,10 @@
      Initialization (on DOM ready)
      */
     $(doc).ready(Photobox.initOverlayDom = function(){
-        // remove old content to make this idempotent (useful for Turbolinks page:restore)
-        $('#pbOverlay').remove();
+        // unbind photobox events (useful when doc.ready is called multiple times, e.g. turbolinks)
         $(doc).off('.photobox');
+        // remove element, if there is one already (e.g. turbolinks page:restore)
+        $('#pbOverlay').remove();
         // DOM structure
         overlay = $('<div id="pbOverlay">').append(
             pbLoader = $('<div class="pbLoader"><b></b><b></b><b></b></div>'),


### PR DESCRIPTION
this makes dom ready idempotent, making it possible to use pb in turbolinks

a turbolinks user would then need to expose Photobox and do:

```
$(document).on('page:restore', window.Photobox.initOverlayDom)
```
