### PR TITLE
Unbind handlers before binding new ones

### DIFF
--- a/photobox/photobox.js
+++ b/photobox/photobox.js
@@ -69,14 +69,14 @@
         
         noPointerEvents && overlay.hide();
 
-        autoplayBtn.on('click', APControl.toggle);
+        autoplayBtn.off('click').on('click', APControl.toggle);
         // attach a delegated event on the thumbs container
-        thumbs.on('click', 'a', thumbsStripe.click);
+        thumbs.off('click', 'a').on('click', 'a', thumbsStripe.click);
         // enable scrolling gesture on mobile
         isMobile && thumbs.css('overflow', 'auto');
         
         // cancel prppogation up to the overlay container so it won't close
-        overlay.on('click', 'img', function(e){
+        overlay.off('click', 'img').on('click', 'img', function(e){
             e.stopPropagation();
         });
 


### PR DESCRIPTION
Sometimes `photobox.open` may be called before `close`. 

E.g.: `history: true` and 
1. open a photobox with 4+ photos
2. mouse click next
3. click history back
4. press right arrow key => it skips through 1 photo

This PR simply ensures that no handlers are never binded more than once.
