### PR TITLE
Eliminate high CPU usage / battery drain on mobile

### DIFF
--- a/photobox/jquery.photobox.js
+++ b/photobox/jquery.photobox.js
@@ -56,7 +56,7 @@
         // DOM structure
         overlay =   $('<div id="pbOverlay">').append(
                         thumbsToggler = $('<input type="checkbox" id="pbThumbsToggler" checked hidden>'),
-                        pbLoader = $('<div class="pbLoader"><b></b><b></b><b></b></div>'),
+                        pbLoader = $('<div id="pbLoader"><b></b><b></b><b></b></div>'),
                         prevBtn = $('<div id="pbPrevBtn" class="prevNext"><b></b></div>').on('click', next_prev),
                         nextBtn = $('<div id="pbNextBtn" class="prevNext"><b></b></div>').on('click', next_prev),
                         wrapper = $('<div class="pbWrapper">').append(  // gives Perspective
@@ -355,6 +355,7 @@
 
             if( open ){
                 image.css({'transition':'0s'}).removeAttr('style'); // reset any transition that might be on the element (yes it's ugly)
+                $("#pbLoader").addClass('pbLoader');
                 overlay.show();
                 // Clean up if another gallery was viewed before, which had a thumbsList
                 thumbs
@@ -391,6 +392,7 @@
 
             } else {
                 $(win).off('resize.photobox');
+                $("#pbLoader").removeClass('pbLoader');
             }
 
             $(doc).off("keydown.photobox")[fn]({ "keydown.photobox": keyDown });


### PR DESCRIPTION
Modified to only use the pbLoader class when the user views slideshow. The pbLoader class uses css animation. CPU usage is high when animation is enabled - which was always without this change.
CPU usage and battery consumption (mobile) drops to next to nothing when the user is not viewing the slideshow because constant DOM rendering is eliminated.