### PR TITLE
Bug with "data-pb-captionlink" attribute fixed

### DIFF
--- a/photobox/jquery.photobox.js
+++ b/photobox/jquery.photobox.js
@@ -460,6 +460,12 @@
                         continue;
 
                     title = this.images[i][1];
+
+                    var matches = title.match(/<a.+?>(.+?)<\/a>/i);
+                    if (matches) {
+                        title = matches[1];
+                    }
+
                     type = link.rel ? " class='" + link.rel +"'" : '';
                     elements.push('<li'+ type +'><a href="'+ link.href +'"><img src="'+ thumbSrc +'" alt="" title="'+ title +'" /></a></li>');
                 };

--- a/photobox/jquery.photobox.js
+++ b/photobox/jquery.photobox.js
@@ -291,7 +291,9 @@
                     thumbSrc = thumbImg.getAttribute(that.options.thumbAttr) || thumbImg.getAttribute('src');
                     caption.content = ( thumbImg.getAttribute('alt') || thumbImg.getAttribute('title') || '');
                 }
-
+                else{
+                    captionlink = '';
+                }
 
                 // if there is a caption link to be added:
                 if( captionlink ){

--- a/photobox/jquery.photobox.js
+++ b/photobox/jquery.photobox.js
@@ -754,8 +754,15 @@
             }
             caption.find('.counter').text(value);
         }
-        if( options.title )
-            caption.find('.title').html('<span>' + images[activeImage][1] + '</span>');
+        if( options.title ){
+            var link = images[activeImage][1];
+            var matches = link.match(/<a(.+?)>(.+?)<\/a>/i);
+            if (matches) {
+                link = '<a' + matches[1] + ' target="_blank">' + matches[2] + '</a>';
+            }
+
+            caption.find('.title').html('<span>' + link + '</span>');
+        }
     }
 
     // Handles the history states when changing images


### PR DESCRIPTION
There is a bug with complex data in "data-pb-captionlink" attribute. It generates <a> tag for the image caption and insert this tag in the "title" attribute of image thumbnails. This breaks HTML code.