### PR TITLE
Fix 2s swipe delay

### DIFF
--- a/photobox/jquery.photobox.js
+++ b/photobox/jquery.photobox.js
@@ -544,11 +544,11 @@
     function onSwipe(e, Dx, Dy){
         if( Dx == 1 ){
             image.css({transform:'translateX(25%)', transition:'.2s', opacity:0});
-            setTimeout(function(){ changeImage(prevImage) }, 200);
+            changeImage(prevImage);
         }
         else if( Dx == -1 ){
             image.css({transform:'translateX(-25%)', transition:'.2s', opacity:0});
-            setTimeout(function(){ changeImage(nextImage) }, 200);
+            changeImage(nextImage);
         }
 
         if( Dy == 1 )


### PR DESCRIPTION
Removes the setTimeout before `changeImage` in `onSwipe`.
Because of that setTimeout, `transitionend` never fired on the image element, resulting in a 2-second delay before the image is shown.